### PR TITLE
Docs: Rewrite README.md from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,64 @@
-<h1 align="center">
-  <br>
-  <img src="./images/logo.png" alt="logo" width="200">
-  <br>
-  GameLib
-  <br>
-</h1>
-<h4 align="center"> A library for 2D game development on C</h4>
+# GameLib
 
-This repo contains a really simple library for developing 2D games!</br> 
+GameLib is a 2D game development library written in C, designed to simplify the creation of games by providing core functionalities like entity management, drawing, audio, and input handling.
 
-### Preview🙈:
-(Make a video of the demo and upload it)
+## How to Build and Use
 
-### How to use⬇️:
-1. Clone this repo.
-```shell
-git clone https://github.com/Kableado/GameLib.git
-cd GameLib
-```
-2. Run `cmake` inside this repo's main directory.
-```shell
-cmake ./
-cmake --build ./
-```
+### Prerequisites
 
-3. Link the libGamelib.a file with your project!
+Before building GameLib, ensure you have the following installed:
+*   A C compiler (e.g., GCC, Clang)
+*   CMake (version 3.10 or higher)
+*   SDL2 library (development headers and libraries)
+*   OpenGL library (development headers and libraries)
 
+*(Note: For Emscripten builds, SDL2 and OpenGL are handled differently as specified in `CMakeLists.txt`)*
 
-Now that you built the library using cmake, its time to Link it!
-Either take a look at directory Example.Gamelib to figure out how to link with cmake OR copy the ```libGameLib.a``` file to your project, copy all the header files in this project's ```src/``` to ```/usr/local/include``` and link manually with gcc.
+### Building the Library
 
-### Documentation📖:
-This project's documantation is work-in progress but I'm trying to document the source code for now!
+1.  **Clone the repository:**
+    ```shell
+    git clone https://github.com/Kableado/GameLib.git
+    cd GameLib
+    ```
 
-### Work in progress⚒️:
-This is still a work in progress project!
+2.  **Configure and build with CMake:**
+    Run CMake in the root directory of the project to generate build files, then build the library.
+    ```shell
+    cmake ./
+    cmake --build ./
+    ```
+    This will produce the static library `libGameLib.a` in the current directory.
 
+### Linking GameLib with Your Project
 
-### Thank you Stargazers⭐:
-[![Stargazers repo roster for @Kableado/GameLib](http://reporoster.com/stars/Kableado/GameLib)](https://github.com/Kableado/GameLib/stargazers)
+There are two main ways to link GameLib:
 
-### Thank you Forkers🍴:
-[![Forkers repo roster for @Kableado/GameLib](http://reporoster.com/forks/Kableado/GameLib)](https://github.com/pKableado/GameLib/network/members)
+1.  **Using CMake (Recommended):**
+    The `Example.GameLib/` directory in this repository demonstrates how to link GameLib with a CMake-based project. You can use its `CMakeLists.txt` as a reference. Typically, this involves using `add_subdirectory()` to include GameLib in your project or `find_package()` if GameLib is installed system-wide.
+
+2.  **Manual Linking:**
+    *   Copy the generated `libGameLib.a` file to your project's library directory.
+    *   Copy all header files from the `src/` directory of GameLib into your project's include path (or a standard system include path like `/usr/local/include/gamelib/` if you prefer).
+    *   When compiling your game, ensure you link against `libGameLib.a` and its dependencies (SDL2, OpenGL, and `m` for math). For example, with GCC:
+        ```shell
+        gcc your_game_code.c -L/path/to/gamelib_library -lGameLib -lSDL2 -lGL -lm -o your_game
+        ```
+        (Adjust paths and library names as per your system setup.)
+
+## Project Structure
+
+Here's an overview of the key directories and files in the GameLib repository:
+
+*   `src/`: Contains all the source code (`.c` files) and public header files (`.h` files) for the GameLib library.
+*   `Example.GameLib/`: An example game project that demonstrates how to integrate and use the GameLib library. It includes its own `CMakeLists.txt` and sample game code.
+*   `cmake/`: Contains CMake helper scripts used during the build process (e.g., `FindSDL2.cmake`).
+*   `LICENSE.txt`: Contains the full text of the MIT License under which GameLib is distributed.
+*   `README.md`: This file, providing information about the library.
+*   `CMakeLists.txt`: The main CMake build script for compiling the GameLib library.
+
+## License
+
+GameLib is distributed under the **MIT License**. See the `LICENSE.txt` file for the full license text.
+
+Copyright (c) 2012-2023 Valeriano Alfonso Rodriguez


### PR DESCRIPTION
This commit replaces the previous README.md with a new version, written from scratch to provide clear and accurate information about the GameLib project.

The new README includes the following sections:
- Title and Short Description
- How to Build and Use (including prerequisites, build steps, and linking instructions)
- Project Structure (overview of key directories)
- License (specifying MIT License)

This rewrite aims to address previous issues and provide a solid foundation for project documentation.